### PR TITLE
Allow using Teamo in DMs and remove prefix

### DIFF
--- a/src/HelpCommand.ts
+++ b/src/HelpCommand.ts
@@ -1,0 +1,21 @@
+import getLanguageResource from "./LanguageResource";
+import * as Discord from 'discord.js';
+
+export async function handleHelpCommand(channel: Discord.TextChannel | Discord.DMChannel, client: Discord.Client, isWelcomeMessage: boolean = false) {
+let helpEmbed = new Discord.MessageEmbed()
+        .setColor("PURPLE")
+        .setTitle(`**${getLanguageResource("HELP_TITLE")}**`)
+        .setDescription("\n[GitHub](https://github.com/hassanbot/teamo)\n\n" + getLanguageResource("HELP_DESCRIPTION"))
+        .addField(getLanguageResource("HELP_FORMAT_TITLE"), getLanguageResource("HELP_FORMAT_FIELD"))
+        .addField(getLanguageResource("HELP_EXAMPLE_TITLE"),
+            `${client.user} 5 20:00 League of Legends` + "\n" +
+            `${client.user} 6 14:26 OW` + "\n" +
+            `[${getLanguageResource('IN_PRIVATE_MESSAGE')}] 3 16:20 Fortnite`);
+    if (!isWelcomeMessage)
+        helpEmbed.setFooter(getLanguageResource("HELP_FOOTER"));
+
+    let msg = await channel.send(helpEmbed) as Discord.Message;
+
+    if (!isWelcomeMessage)
+        msg.delete({ timeout: 60000 });
+}

--- a/src/LanguageResource.ts
+++ b/src/LanguageResource.ts
@@ -23,8 +23,8 @@ const LanguageObject: LanguageDict = {
         "english": "Format"
     },
     "HELP_FORMAT_FIELD": {
-        "swedish": "!teamo <antal spelare per lag> <starttid (hh:mm)> <spel>",
-        "english": "!teamo <number of players per team> <time to start (hh:mm)> <game>"
+        "swedish": "<antal spelare per lag> <starttid (hh:mm)> <spel>",
+        "english": "<number of players per team> <time to start (hh:mm)> <game>"
     },
     "HELP_EXAMPLE_TITLE": {
         "swedish": "Exempel",
@@ -70,9 +70,13 @@ const LanguageObject: LanguageDict = {
         "swedish": "Uppdateras var 15:e sekund. Senast uppdaterad",
         "english": "Updated every 15th second. Last update"
     },
-    "ARGS_PLAY_INVALID_FORMAT": {
-        "swedish": "Fel format på kommandot. Rätt format: \"!teamo <spelare> <hh>:<mm> <spel>\". Skriv **!teamo help** för mer info.",
-        "english": "Invalid format. The command should be on the form: \"!teamo <players> <hh>:<mm> <game[]>\". Type **!teamo help** for more info."
+    "ARGS_PLAY_INVALID_FORMAT_1": {
+        "swedish": "Fel format på kommandot. Rätt format: \"<spelare> <hh>:<mm> <spel>\". Se",
+        "english": "Invalid format. The command should be on the form: \"<players> <hh>:<mm> <game>\". See"
+    },
+    "ARGS_PLAY_INVALID_FORMAT_2": {
+        "swedish": "för mer info.",
+        "english": "for more info."
     },
     "DELETION_TITLE": {
         "swedish": "MEDDELANDET TAS BORT",
@@ -97,6 +101,14 @@ const LanguageObject: LanguageDict = {
     "WRONG_CHANNEL": {
         "swedish": "Teamo kan bara användas från",
         "english": "Teamo can only be used from"
+    },
+    "NEW_MESSAGE_CREATED_DM": {
+        "swedish": "Meddelande skapat i",
+        "english": "Message created in"
+    },
+    "IN_PRIVATE_MESSAGE": {
+        "swedish": "i privat meddelande",
+        "english": "in direct message"
     }
 }
 
@@ -104,5 +116,5 @@ export default function getLanguageResource(desc: string) {
     if (desc in LanguageObject)
         return LanguageObject[desc][config.language];
     else
-        throw Error("Invalid language description");
+        return "INVALID LOCALIZATION STRING";
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,17 +1,13 @@
 type Config = {
     token: string,
-    prefix: string,
     language: "swedish" | "english",
     updateInterval: number,
-    useSpecificChannel: boolean,
     channelID: string
 }
 
 export const config: Config = {
     "token": process.env.TEAMO_BOT_TOKEN,
-    "prefix": "!",
     "language": "swedish",
     "updateInterval": 15,
-    "useSpecificChannel": true,
     "channelID": process.env.TEAMO_CHANNEL_ID || "-1"
 }


### PR DESCRIPTION
- Allow sending DMs to Teamo
- Address Teamo in channels by using `@Teamo` instead of `[prefix]teamo`
- Always post Teamo messages in specified channel

Fixes #27
Fixes #28